### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/multi-event.yml
+++ b/.github/workflows/multi-event.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   hello_world:
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - name: "Echo Basic Information"


### PR DESCRIPTION
Potential fix for [https://github.com/mamathadhanoji/Github-Actions-Examples/security/code-scanning/2](https://github.com/mamathadhanoji/Github-Actions-Examples/security/code-scanning/2)

In general, the fix is to explicitly set a `permissions:` block either at the top level of the workflow (applying to all jobs) or for the specific job, granting only the minimal scopes required. Since this job only echoes environment variables and does not use the GITHUB_TOKEN, we can safely set `permissions: { contents: read }` or even `permissions: {}` at the job level. GitHub recommends at least specifying read-level scopes when appropriate; however, when the token is unused, `permissions: {}` (no permissions) is the most restrictive and clearly communicates intent.

The best single fix here without changing functionality is to add a `permissions: {}` block directly under the `hello_world` job (line 12–13 region), keeping the scope of the change local to the flagged job. This tells GitHub Actions to grant no permissions to the GITHUB_TOKEN for this job. Concretely, edit `.github/workflows/multi-event.yml` so that under `jobs: hello_world:` and before `runs-on: ubuntu-latest`, we insert a `permissions: {}` line indented correctly. No imports or additional methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
