### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/custom-action.yml
+++ b/.github/workflows/custom-action.yml
@@ -3,6 +3,8 @@ on: [push]
 jobs:
   my-job:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     name: A job to say hello
     steps:
       - name: Hello world action step


### PR DESCRIPTION
Potential fix for [https://github.com/mamathadhanoji/Github-Actions-Examples/security/code-scanning/1](https://github.com/mamathadhanoji/Github-Actions-Examples/security/code-scanning/1)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal required scopes for the job or workflow. If the job does not need to modify repo contents, issues, PRs, or other resources, we can safely set `contents: read`, which is equivalent to a read‑only default, or even `contents: none` if no repo access is needed.

For this specific workflow, the job simply runs a custom action and echoes its output; there is no evidence of any write operations. A safe and minimal change is to add a `permissions:` block at the job level (under `my-job:` and aligned with `runs-on:`) with `contents: read`. This keeps existing functionality intact while constraining `GITHUB_TOKEN`. No additional imports or methods are needed, as this is a YAML configuration change only. The edit should be made in `.github/workflows/custom-action.yml` right after the `runs-on: ubuntu-latest` line or as the first key under `my-job:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
